### PR TITLE
Fix wrong positional args in grpo_compute_loss_slow call

### DIFF
--- a/unsloth/models/rl_replacements.py
+++ b/unsloth/models/rl_replacements.py
@@ -1131,6 +1131,7 @@ def grpo_trainer_compute_loss(function_name, function):
                 ref_logps,
                 per_token_logps,
                 old_logps,
+                sampling_per_token_logps,
                 input_ids,
                 completion_mask,
                 self.beta,
@@ -1151,7 +1152,6 @@ def grpo_trainer_compute_loss(function_name, function):
                 num_items_in_batch = num_items_in_batch,
                 current_gradient_accumulation_steps = current_gradient_accumulation_steps,
                 num_processes = num_processes,
-                sampling_per_token_logps = sampling_per_token_logps,
             )
         else:
             if hasattr(self.args, "loss_type"):


### PR DESCRIPTION
## Staging mirror of unslothai/unsloth#4927

Original PR: https://github.com/unslothai/unsloth/pull/4927
Author: Shivamjohri247

This is a staging copy for review and editing. Once finalized, changes will be pushed back to the original PR.

---

### Original description

## Summary

Fixes #4885

The call to `grpo_compute_loss_slow` in the `compute_loss` replacement for `GRPOTrainer` was passing arguments in the wrong positions, causing a crash during GRPO training.

### Root Cause

`grpo_compute_loss` (and its `torch.compile`d variant `grpo_compute_loss_slow`) has this signature (defined in `unsloth-zoo`):

```python
def grpo_compute_loss(ref, new, old, sampling_per_token_logps, input_ids, mask, beta, advantages, **kwargs):
```

The call site in `unsloth/models/rl_replacements.py:1130` was **skipping** the 4th positional argument (`sampling_per_token_logps`) and also passing it as a keyword arg at the end:

```python
# BEFORE (broken)
grpo_compute_loss_slow(
    ref_logps,           # ref           ✓
    per_token_logps,     # new           ✓
    old_logps,           # old           ✓
    input_ids,           # → sampling_per_token_logps  ✗ WRONG
    completion_mask,     # → input_ids               ✗ WRONG
    self.beta,           # → mask                    ✗ WRONG
    advantages,          # → beta                    ✗ WRONG
    ...,
    sampling_per_token_logps = sampling_per_token_logps,  # duplicate! causes TypeError
)
```

This caused a `TypeError: got multiple values for argument 'sampling_per_token_logps'` at runtime, since the 4th positional slot was already filled by `input_ids`, and then the same parameter name was also provided as a keyword argument.

### Fix

Insert `sampling_per_token_logps` as the 4th positional argument (matching the function signature) and remove it from keyword args:

```python
# AFTER (fixed)
grpo_compute_loss_slow(
    ref_logps,                  # ref                       ✓
    per_token_logps,            # new                       ✓
    old_logps,                  # old                       ✓
    sampling_per_token_logps,   # sampling_per_token_logps  ✓ NEW
    input_ids,                  # input_ids                 ✓
    completion_mask,            # mask                      ✓
    self.beta,                  # beta                      ✓
    advantages,                 # advantages                ✓
    ...,
    # sampling_per_token_logps removed from kwargs
)
```

This now matches the calling convention used by `UnslothEfficientGRPO.forward()` (the fast/compiled path) which already passes args in the correct order.

### Impact

- **Before**: GRPO training crashes with `TypeError` when using the slow loss computation path (when `per_token_logps is not None`)
- **After**: Arguments correctly map to their intended parameters

## Test plan

- [ ] Run GRPO training with `GRPOTrainer` using a model that triggers the `grpo_compute_loss_slow` path (i.e. where `_get_per_token_logps` returns non-None logprobs)
- [ ] Verify training completes without `TypeError`
- [ ] Verify loss values and metrics are computed correctly (no NaN, reasonable magnitudes)