### PR TITLE
[tests] Fix wrong positional args in grpo_compute_loss_slow call

### DIFF
--- a/test_01_pre_pr_typeerror.py
+++ b/test_01_pre_pr_typeerror.py
@@ -1,11 +1,13 @@
 """Reproduce the pre-PR TypeError: grpo_compute_loss gets multiple values for sampling_per_token_logps."""
+
 import sys, torch
+
 sys.path.insert(0, "unsloth_zoo_repo")
 from unsloth_zoo.rl_replacements import grpo_compute_loss
 
 B, S = 2, 8
 ref = torch.randn(B, S)
-new = torch.randn(B, S, requires_grad=True)
+new = torch.randn(B, S, requires_grad = True)
 old = torch.randn(B, S)
 sampling = torch.randn(B, S)
 input_ids = torch.randint(0, 100, (B, S))
@@ -16,15 +18,19 @@ advantages = torch.randn(B)
 # Pre-PR call: sampling_per_token_logps missing from positional args, passed as kwarg
 try:
     grpo_compute_loss(
-        ref, new, old,
-        input_ids,        # WRONG: should be sampling_per_token_logps
-        mask,             # WRONG: should be input_ids
-        beta,             # WRONG: should be mask
-        advantages,       # WRONG: should be beta
-        sampling_per_token_logps=sampling,  # duplicate kwarg
+        ref,
+        new,
+        old,
+        input_ids,  # WRONG: should be sampling_per_token_logps
+        mask,  # WRONG: should be input_ids
+        beta,  # WRONG: should be mask
+        advantages,  # WRONG: should be beta
+        sampling_per_token_logps = sampling,  # duplicate kwarg
     )
     print("FAIL: Expected TypeError was not raised")
     sys.exit(1)
 except TypeError as e:
-    assert "sampling_per_token_logps" in str(e) or "multiple values" in str(e), f"Wrong TypeError: {e}"
+    assert "sampling_per_token_logps" in str(e) or "multiple values" in str(
+        e
+    ), f"Wrong TypeError: {e}"
     print(f"PASS: Pre-PR call correctly raises TypeError: {e}")

--- a/test_01_pre_pr_typeerror.py
+++ b/test_01_pre_pr_typeerror.py
@@ -1,0 +1,30 @@
+"""Reproduce the pre-PR TypeError: grpo_compute_loss gets multiple values for sampling_per_token_logps."""
+import sys, torch
+sys.path.insert(0, "unsloth_zoo_repo")
+from unsloth_zoo.rl_replacements import grpo_compute_loss
+
+B, S = 2, 8
+ref = torch.randn(B, S)
+new = torch.randn(B, S, requires_grad=True)
+old = torch.randn(B, S)
+sampling = torch.randn(B, S)
+input_ids = torch.randint(0, 100, (B, S))
+mask = torch.ones(B, S)
+beta = 0.1
+advantages = torch.randn(B)
+
+# Pre-PR call: sampling_per_token_logps missing from positional args, passed as kwarg
+try:
+    grpo_compute_loss(
+        ref, new, old,
+        input_ids,        # WRONG: should be sampling_per_token_logps
+        mask,             # WRONG: should be input_ids
+        beta,             # WRONG: should be mask
+        advantages,       # WRONG: should be beta
+        sampling_per_token_logps=sampling,  # duplicate kwarg
+    )
+    print("FAIL: Expected TypeError was not raised")
+    sys.exit(1)
+except TypeError as e:
+    assert "sampling_per_token_logps" in str(e) or "multiple values" in str(e), f"Wrong TypeError: {e}"
+    print(f"PASS: Pre-PR call correctly raises TypeError: {e}")

--- a/test_02_post_pr_basic.py
+++ b/test_02_post_pr_basic.py
@@ -1,11 +1,13 @@
 """Confirm the post-PR call with correct positional args succeeds and returns valid output."""
+
 import sys, torch
+
 sys.path.insert(0, "unsloth_zoo_repo")
 from unsloth_zoo.rl_replacements import grpo_compute_loss
 
 B, S = 2, 8
 ref = torch.randn(B, S)
-new = torch.randn(B, S, requires_grad=True)
+new = torch.randn(B, S, requires_grad = True)
 old = torch.randn(B, S)
 sampling = torch.randn(B, S)
 input_ids = torch.randint(0, 100, (B, S))
@@ -14,8 +16,15 @@ beta = 0.1
 advantages = torch.randn(B)
 
 result = grpo_compute_loss(
-    ref, new, old, sampling, input_ids, mask, beta, advantages,
-    loss_type="grpo",
+    ref,
+    new,
+    old,
+    sampling,
+    input_ids,
+    mask,
+    beta,
+    advantages,
+    loss_type = "grpo",
 )
 assert len(result) == 7, f"Expected 7-tuple, got {len(result)}"
 loss, completion_length, mean_kl, delta, flat_is_ratio, coef_1, out_mask = result

--- a/test_02_post_pr_basic.py
+++ b/test_02_post_pr_basic.py
@@ -1,0 +1,24 @@
+"""Confirm the post-PR call with correct positional args succeeds and returns valid output."""
+import sys, torch
+sys.path.insert(0, "unsloth_zoo_repo")
+from unsloth_zoo.rl_replacements import grpo_compute_loss
+
+B, S = 2, 8
+ref = torch.randn(B, S)
+new = torch.randn(B, S, requires_grad=True)
+old = torch.randn(B, S)
+sampling = torch.randn(B, S)
+input_ids = torch.randint(0, 100, (B, S))
+mask = torch.ones(B, S)
+beta = 0.1
+advantages = torch.randn(B)
+
+result = grpo_compute_loss(
+    ref, new, old, sampling, input_ids, mask, beta, advantages,
+    loss_type="grpo",
+)
+assert len(result) == 7, f"Expected 7-tuple, got {len(result)}"
+loss, completion_length, mean_kl, delta, flat_is_ratio, coef_1, out_mask = result
+assert torch.isfinite(loss), f"Loss is not finite: {loss}"
+assert torch.isfinite(mean_kl), f"mean_kl is not finite: {mean_kl}"
+print(f"PASS: loss={loss.item():.4f}, mean_kl={mean_kl.item():.4f}")

--- a/test_03_sampling_none.py
+++ b/test_03_sampling_none.py
@@ -1,11 +1,13 @@
 """Test sampling_per_token_logps=None (most common production path)."""
+
 import sys, torch
+
 sys.path.insert(0, "unsloth_zoo_repo")
 from unsloth_zoo.rl_replacements import grpo_compute_loss
 
 B, S = 2, 8
 ref = torch.randn(B, S)
-new = torch.randn(B, S, requires_grad=True)
+new = torch.randn(B, S, requires_grad = True)
 old = torch.randn(B, S)
 input_ids = torch.randint(0, 100, (B, S))
 mask = torch.ones(B, S)
@@ -13,8 +15,15 @@ beta = 0.1
 advantages = torch.randn(B)
 
 result = grpo_compute_loss(
-    ref, new, old, None, input_ids, mask, beta, advantages,
-    loss_type="grpo",
+    ref,
+    new,
+    old,
+    None,
+    input_ids,
+    mask,
+    beta,
+    advantages,
+    loss_type = "grpo",
 )
 assert len(result) == 7
 loss = result[0]

--- a/test_03_sampling_none.py
+++ b/test_03_sampling_none.py
@@ -1,0 +1,22 @@
+"""Test sampling_per_token_logps=None (most common production path)."""
+import sys, torch
+sys.path.insert(0, "unsloth_zoo_repo")
+from unsloth_zoo.rl_replacements import grpo_compute_loss
+
+B, S = 2, 8
+ref = torch.randn(B, S)
+new = torch.randn(B, S, requires_grad=True)
+old = torch.randn(B, S)
+input_ids = torch.randint(0, 100, (B, S))
+mask = torch.ones(B, S)
+beta = 0.1
+advantages = torch.randn(B)
+
+result = grpo_compute_loss(
+    ref, new, old, None, input_ids, mask, beta, advantages,
+    loss_type="grpo",
+)
+assert len(result) == 7
+loss = result[0]
+assert torch.isfinite(loss), f"Loss not finite: {loss}"
+print(f"PASS: sampling=None, loss={loss.item():.4f}")

--- a/test_04_old_logps_none.py
+++ b/test_04_old_logps_none.py
@@ -1,0 +1,22 @@
+"""Test old_logps=None (dapo path where old is not available)."""
+import sys, torch
+sys.path.insert(0, "unsloth_zoo_repo")
+from unsloth_zoo.rl_replacements import grpo_compute_loss
+
+B, S = 2, 8
+ref = torch.randn(B, S)
+new = torch.randn(B, S, requires_grad=True)
+input_ids = torch.randint(0, 100, (B, S))
+mask = torch.ones(B, S)
+beta = 0.1
+advantages = torch.randn(B)
+
+# old=None triggers log_ratio = new - new.detach()
+result = grpo_compute_loss(
+    ref, new, None, None, input_ids, mask, beta, advantages,
+    loss_type="dapo", num_items_in_batch=B, num_processes=1,
+)
+assert len(result) == 7
+loss = result[0]
+assert torch.isfinite(loss), f"Loss not finite: {loss}"
+print(f"PASS: old=None (dapo), loss={loss.item():.4f}")

--- a/test_04_old_logps_none.py
+++ b/test_04_old_logps_none.py
@@ -1,11 +1,13 @@
 """Test old_logps=None (dapo path where old is not available)."""
+
 import sys, torch
+
 sys.path.insert(0, "unsloth_zoo_repo")
 from unsloth_zoo.rl_replacements import grpo_compute_loss
 
 B, S = 2, 8
 ref = torch.randn(B, S)
-new = torch.randn(B, S, requires_grad=True)
+new = torch.randn(B, S, requires_grad = True)
 input_ids = torch.randint(0, 100, (B, S))
 mask = torch.ones(B, S)
 beta = 0.1
@@ -13,8 +15,17 @@ advantages = torch.randn(B)
 
 # old=None triggers log_ratio = new - new.detach()
 result = grpo_compute_loss(
-    ref, new, None, None, input_ids, mask, beta, advantages,
-    loss_type="dapo", num_items_in_batch=B, num_processes=1,
+    ref,
+    new,
+    None,
+    None,
+    input_ids,
+    mask,
+    beta,
+    advantages,
+    loss_type = "dapo",
+    num_items_in_batch = B,
+    num_processes = 1,
 )
 assert len(result) == 7
 loss = result[0]

--- a/test_05_beta_zero.py
+++ b/test_05_beta_zero.py
@@ -1,0 +1,22 @@
+"""Test beta=0 path (no KL divergence term)."""
+import sys, torch
+sys.path.insert(0, "unsloth_zoo_repo")
+from unsloth_zoo.rl_replacements import grpo_compute_loss
+
+B, S = 2, 8
+ref = torch.randn(B, S)
+new = torch.randn(B, S, requires_grad=True)
+old = torch.randn(B, S)
+input_ids = torch.randint(0, 100, (B, S))
+mask = torch.ones(B, S)
+advantages = torch.randn(B)
+
+result = grpo_compute_loss(
+    ref, new, old, None, input_ids, mask, 0.0, advantages,
+    loss_type="grpo",
+)
+assert len(result) == 7
+loss, completion_length, mean_kl = result[0], result[1], result[2]
+assert torch.isfinite(loss), f"Loss not finite: {loss}"
+assert mean_kl.item() == 0.0, f"Expected mean_kl=0 with beta=0, got {mean_kl}"
+print(f"PASS: beta=0, loss={loss.item():.4f}, mean_kl={mean_kl.item():.4f}")

--- a/test_05_beta_zero.py
+++ b/test_05_beta_zero.py
@@ -1,19 +1,28 @@
 """Test beta=0 path (no KL divergence term)."""
+
 import sys, torch
+
 sys.path.insert(0, "unsloth_zoo_repo")
 from unsloth_zoo.rl_replacements import grpo_compute_loss
 
 B, S = 2, 8
 ref = torch.randn(B, S)
-new = torch.randn(B, S, requires_grad=True)
+new = torch.randn(B, S, requires_grad = True)
 old = torch.randn(B, S)
 input_ids = torch.randint(0, 100, (B, S))
 mask = torch.ones(B, S)
 advantages = torch.randn(B)
 
 result = grpo_compute_loss(
-    ref, new, old, None, input_ids, mask, 0.0, advantages,
-    loss_type="grpo",
+    ref,
+    new,
+    old,
+    None,
+    input_ids,
+    mask,
+    0.0,
+    advantages,
+    loss_type = "grpo",
 )
 assert len(result) == 7
 loss, completion_length, mean_kl = result[0], result[1], result[2]

--- a/test_06_loss_types.py
+++ b/test_06_loss_types.py
@@ -1,11 +1,13 @@
 """Test all supported loss types produce finite results."""
+
 import sys, torch
+
 sys.path.insert(0, "unsloth_zoo_repo")
 from unsloth_zoo.rl_replacements import grpo_compute_loss
 
 B, S = 4, 8
 ref = torch.randn(B, S)
-new = torch.randn(B, S, requires_grad=True)
+new = torch.randn(B, S, requires_grad = True)
 old = torch.randn(B, S)
 input_ids = torch.randint(0, 100, (B, S))
 mask = torch.ones(B, S)
@@ -21,10 +23,18 @@ loss_types = {
 }
 
 for lt, extra_kwargs in loss_types.items():
-    new_t = torch.randn(B, S, requires_grad=True)
+    new_t = torch.randn(B, S, requires_grad = True)
     result = grpo_compute_loss(
-        ref, new_t, old, None, input_ids, mask, beta, advantages,
-        loss_type=lt, **extra_kwargs,
+        ref,
+        new_t,
+        old,
+        None,
+        input_ids,
+        mask,
+        beta,
+        advantages,
+        loss_type = lt,
+        **extra_kwargs,
     )
     assert len(result) == 7, f"{lt}: expected 7-tuple"
     assert torch.isfinite(result[0]), f"{lt}: loss not finite: {result[0]}"

--- a/test_06_loss_types.py
+++ b/test_06_loss_types.py
@@ -1,0 +1,33 @@
+"""Test all supported loss types produce finite results."""
+import sys, torch
+sys.path.insert(0, "unsloth_zoo_repo")
+from unsloth_zoo.rl_replacements import grpo_compute_loss
+
+B, S = 4, 8
+ref = torch.randn(B, S)
+new = torch.randn(B, S, requires_grad=True)
+old = torch.randn(B, S)
+input_ids = torch.randint(0, 100, (B, S))
+mask = torch.ones(B, S)
+beta = 0.1
+advantages = torch.randn(B)
+
+loss_types = {
+    "grpo": {},
+    "bnpo": {},
+    "dr_grpo": {"max_completion_length": S},
+    "dapo": {"num_items_in_batch": B, "num_processes": 1},
+    "cispo": {"num_items_in_batch": B, "num_processes": 1},
+}
+
+for lt, extra_kwargs in loss_types.items():
+    new_t = torch.randn(B, S, requires_grad=True)
+    result = grpo_compute_loss(
+        ref, new_t, old, None, input_ids, mask, beta, advantages,
+        loss_type=lt, **extra_kwargs,
+    )
+    assert len(result) == 7, f"{lt}: expected 7-tuple"
+    assert torch.isfinite(result[0]), f"{lt}: loss not finite: {result[0]}"
+    print(f"PASS: loss_type={lt}, loss={result[0].item():.4f}")
+
+print("PASS: All loss types OK")

--- a/test_07_importance_sampling_levels.py
+++ b/test_07_importance_sampling_levels.py
@@ -1,5 +1,7 @@
 """Test token vs sequence importance sampling levels."""
+
 import sys, torch
+
 sys.path.insert(0, "unsloth_zoo_repo")
 from unsloth_zoo.rl_replacements import grpo_compute_loss
 
@@ -12,21 +14,36 @@ beta = 0.1
 advantages = torch.randn(B)
 
 for level in ["token", "sequence"]:
-    new = torch.randn(B, S, requires_grad=True)
+    new = torch.randn(B, S, requires_grad = True)
     result = grpo_compute_loss(
-        ref, new, old, None, input_ids, mask, beta, advantages,
-        loss_type="grpo", importance_sampling_level=level,
+        ref,
+        new,
+        old,
+        None,
+        input_ids,
+        mask,
+        beta,
+        advantages,
+        loss_type = "grpo",
+        importance_sampling_level = level,
     )
     assert len(result) == 7
     assert torch.isfinite(result[0]), f"{level}: loss not finite"
     print(f"PASS: importance_sampling_level={level}, loss={result[0].item():.4f}")
 
 # Invalid level should raise
-new = torch.randn(B, S, requires_grad=True)
+new = torch.randn(B, S, requires_grad = True)
 try:
     grpo_compute_loss(
-        ref, new, old, None, input_ids, mask, beta, advantages,
-        importance_sampling_level="invalid",
+        ref,
+        new,
+        old,
+        None,
+        input_ids,
+        mask,
+        beta,
+        advantages,
+        importance_sampling_level = "invalid",
     )
     print("FAIL: Expected ValueError for invalid importance_sampling_level")
     sys.exit(1)

--- a/test_07_importance_sampling_levels.py
+++ b/test_07_importance_sampling_levels.py
@@ -1,0 +1,34 @@
+"""Test token vs sequence importance sampling levels."""
+import sys, torch
+sys.path.insert(0, "unsloth_zoo_repo")
+from unsloth_zoo.rl_replacements import grpo_compute_loss
+
+B, S = 4, 8
+ref = torch.randn(B, S)
+old = torch.randn(B, S)
+input_ids = torch.randint(0, 100, (B, S))
+mask = torch.ones(B, S)
+beta = 0.1
+advantages = torch.randn(B)
+
+for level in ["token", "sequence"]:
+    new = torch.randn(B, S, requires_grad=True)
+    result = grpo_compute_loss(
+        ref, new, old, None, input_ids, mask, beta, advantages,
+        loss_type="grpo", importance_sampling_level=level,
+    )
+    assert len(result) == 7
+    assert torch.isfinite(result[0]), f"{level}: loss not finite"
+    print(f"PASS: importance_sampling_level={level}, loss={result[0].item():.4f}")
+
+# Invalid level should raise
+new = torch.randn(B, S, requires_grad=True)
+try:
+    grpo_compute_loss(
+        ref, new, old, None, input_ids, mask, beta, advantages,
+        importance_sampling_level="invalid",
+    )
+    print("FAIL: Expected ValueError for invalid importance_sampling_level")
+    sys.exit(1)
+except ValueError:
+    print("PASS: Invalid importance_sampling_level raises ValueError")

--- a/test_08_return_shape.py
+++ b/test_08_return_shape.py
@@ -1,0 +1,31 @@
+"""Verify return tuple shape, types, and gradient flow."""
+import sys, torch
+sys.path.insert(0, "unsloth_zoo_repo")
+from unsloth_zoo.rl_replacements import grpo_compute_loss
+
+B, S = 2, 8
+ref = torch.randn(B, S)
+new = torch.randn(B, S, requires_grad=True)
+old = torch.randn(B, S)
+sampling = torch.randn(B, S)
+input_ids = torch.randint(0, 100, (B, S))
+mask = torch.ones(B, S)
+beta = 0.1
+advantages = torch.randn(B)
+
+loss, completion_length, mean_kl, delta, flat_is_ratio, coef_1, out_mask = grpo_compute_loss(
+    ref, new, old, sampling, input_ids, mask, beta, advantages,
+)
+
+# Check types
+assert loss.dim() == 0, f"loss should be scalar, got dim={loss.dim()}"
+assert completion_length.dim() == 0, f"completion_length should be scalar"
+assert mean_kl.dim() == 0, f"mean_kl should be scalar"
+assert out_mask.shape == (B, S), f"mask shape mismatch: {out_mask.shape}"
+assert coef_1.shape == (B, S), f"coef_1 shape mismatch: {coef_1.shape}"
+
+# Check gradient flows through loss
+loss.backward()
+assert new.grad is not None, "Gradient did not flow to new logps"
+assert torch.isfinite(new.grad).all(), "Gradients contain non-finite values"
+print(f"PASS: Return shapes correct, gradients flow properly")

--- a/test_08_return_shape.py
+++ b/test_08_return_shape.py
@@ -1,11 +1,13 @@
 """Verify return tuple shape, types, and gradient flow."""
+
 import sys, torch
+
 sys.path.insert(0, "unsloth_zoo_repo")
 from unsloth_zoo.rl_replacements import grpo_compute_loss
 
 B, S = 2, 8
 ref = torch.randn(B, S)
-new = torch.randn(B, S, requires_grad=True)
+new = torch.randn(B, S, requires_grad = True)
 old = torch.randn(B, S)
 sampling = torch.randn(B, S)
 input_ids = torch.randint(0, 100, (B, S))
@@ -13,8 +15,17 @@ mask = torch.ones(B, S)
 beta = 0.1
 advantages = torch.randn(B)
 
-loss, completion_length, mean_kl, delta, flat_is_ratio, coef_1, out_mask = grpo_compute_loss(
-    ref, new, old, sampling, input_ids, mask, beta, advantages,
+loss, completion_length, mean_kl, delta, flat_is_ratio, coef_1, out_mask = (
+    grpo_compute_loss(
+        ref,
+        new,
+        old,
+        sampling,
+        input_ids,
+        mask,
+        beta,
+        advantages,
+    )
 )
 
 # Check types

--- a/test_09_vllm_importance_sampling.py
+++ b/test_09_vllm_importance_sampling.py
@@ -1,11 +1,13 @@
 """Test use_vllm=True with sampling_per_token_logps (importance sampling correction)."""
+
 import sys, torch
+
 sys.path.insert(0, "unsloth_zoo_repo")
 from unsloth_zoo.rl_replacements import grpo_compute_loss
 
 B, S = 2, 8
 ref = torch.randn(B, S)
-new = torch.randn(B, S, requires_grad=True)
+new = torch.randn(B, S, requires_grad = True)
 old = torch.randn(B, S)
 sampling = torch.randn(B, S)
 input_ids = torch.randint(0, 100, (B, S))
@@ -15,8 +17,16 @@ advantages = torch.randn(B)
 
 # With vllm and sampling logps
 result = grpo_compute_loss(
-    ref, new, old, sampling, input_ids, mask, beta, advantages,
-    use_vllm=True, vllm_importance_sampling_cap=2.0,
+    ref,
+    new,
+    old,
+    sampling,
+    input_ids,
+    mask,
+    beta,
+    advantages,
+    use_vllm = True,
+    vllm_importance_sampling_cap = 2.0,
 )
 assert len(result) == 7
 loss, _, _, delta, flat_is_ratio, _, _ = result
@@ -26,10 +36,17 @@ assert flat_is_ratio.numel() > 0, "flat_is_ratio should be non-empty with use_vl
 print(f"PASS: use_vllm=True with sampling, loss={loss.item():.4f}")
 
 # With vllm but sampling=None (should skip IS correction)
-new2 = torch.randn(B, S, requires_grad=True)
+new2 = torch.randn(B, S, requires_grad = True)
 result2 = grpo_compute_loss(
-    ref, new2, old, None, input_ids, mask, beta, advantages,
-    use_vllm=True,
+    ref,
+    new2,
+    old,
+    None,
+    input_ids,
+    mask,
+    beta,
+    advantages,
+    use_vllm = True,
 )
 assert len(result2) == 7
 assert torch.isfinite(result2[0]), "Loss not finite with vllm+sampling=None"

--- a/test_09_vllm_importance_sampling.py
+++ b/test_09_vllm_importance_sampling.py
@@ -1,0 +1,37 @@
+"""Test use_vllm=True with sampling_per_token_logps (importance sampling correction)."""
+import sys, torch
+sys.path.insert(0, "unsloth_zoo_repo")
+from unsloth_zoo.rl_replacements import grpo_compute_loss
+
+B, S = 2, 8
+ref = torch.randn(B, S)
+new = torch.randn(B, S, requires_grad=True)
+old = torch.randn(B, S)
+sampling = torch.randn(B, S)
+input_ids = torch.randint(0, 100, (B, S))
+mask = torch.ones(B, S)
+beta = 0.1
+advantages = torch.randn(B)
+
+# With vllm and sampling logps
+result = grpo_compute_loss(
+    ref, new, old, sampling, input_ids, mask, beta, advantages,
+    use_vllm=True, vllm_importance_sampling_cap=2.0,
+)
+assert len(result) == 7
+loss, _, _, delta, flat_is_ratio, _, _ = result
+assert torch.isfinite(loss), f"Loss not finite: {loss}"
+assert delta.numel() > 0, "delta should be non-empty with use_vllm=True"
+assert flat_is_ratio.numel() > 0, "flat_is_ratio should be non-empty with use_vllm=True"
+print(f"PASS: use_vllm=True with sampling, loss={loss.item():.4f}")
+
+# With vllm but sampling=None (should skip IS correction)
+new2 = torch.randn(B, S, requires_grad=True)
+result2 = grpo_compute_loss(
+    ref, new2, old, None, input_ids, mask, beta, advantages,
+    use_vllm=True,
+)
+assert len(result2) == 7
+assert torch.isfinite(result2[0]), "Loss not finite with vllm+sampling=None"
+assert result2[3].numel() == 0, "delta should be empty when sampling=None"
+print(f"PASS: use_vllm=True, sampling=None, loss={result2[0].item():.4f}")

--- a/test_10_1d_advantages.py
+++ b/test_10_1d_advantages.py
@@ -1,0 +1,42 @@
+"""Test 1D advantages auto-unsqueeze and various batch/sequence sizes."""
+import sys, torch
+sys.path.insert(0, "unsloth_zoo_repo")
+from unsloth_zoo.rl_replacements import grpo_compute_loss
+
+# Test 1D advantages (should be auto-unsqueezed to 2D)
+B, S = 4, 16
+ref = torch.randn(B, S)
+new = torch.randn(B, S, requires_grad=True)
+old = torch.randn(B, S)
+input_ids = torch.randint(0, 100, (B, S))
+mask = torch.ones(B, S)
+beta = 0.1
+advantages_1d = torch.randn(B)
+
+result = grpo_compute_loss(
+    ref, new, old, None, input_ids, mask, beta, advantages_1d,
+)
+assert len(result) == 7
+assert torch.isfinite(result[0]), f"1D advantages: loss not finite"
+print(f"PASS: 1D advantages, loss={result[0].item():.4f}")
+
+# Test 2D advantages (already correct shape)
+new2 = torch.randn(B, S, requires_grad=True)
+advantages_2d = torch.randn(B, 1)
+result2 = grpo_compute_loss(
+    ref, new2, old, None, input_ids, mask, beta, advantages_2d,
+)
+assert len(result2) == 7
+assert torch.isfinite(result2[0]), f"2D advantages: loss not finite"
+print(f"PASS: 2D advantages, loss={result2[0].item():.4f}")
+
+# Test various batch/seq sizes
+for b, s in [(1, 1), (1, 32), (8, 4)]:
+    new_t = torch.randn(b, s, requires_grad=True)
+    r = grpo_compute_loss(
+        torch.randn(b, s), new_t, torch.randn(b, s), None,
+        torch.randint(0, 100, (b, s)), torch.ones(b, s),
+        beta, torch.randn(b),
+    )
+    assert torch.isfinite(r[0]), f"B={b},S={s}: loss not finite"
+    print(f"PASS: B={b}, S={s}, loss={r[0].item():.4f}")

--- a/test_10_1d_advantages.py
+++ b/test_10_1d_advantages.py
@@ -1,12 +1,14 @@
 """Test 1D advantages auto-unsqueeze and various batch/sequence sizes."""
+
 import sys, torch
+
 sys.path.insert(0, "unsloth_zoo_repo")
 from unsloth_zoo.rl_replacements import grpo_compute_loss
 
 # Test 1D advantages (should be auto-unsqueezed to 2D)
 B, S = 4, 16
 ref = torch.randn(B, S)
-new = torch.randn(B, S, requires_grad=True)
+new = torch.randn(B, S, requires_grad = True)
 old = torch.randn(B, S)
 input_ids = torch.randint(0, 100, (B, S))
 mask = torch.ones(B, S)
@@ -14,17 +16,31 @@ beta = 0.1
 advantages_1d = torch.randn(B)
 
 result = grpo_compute_loss(
-    ref, new, old, None, input_ids, mask, beta, advantages_1d,
+    ref,
+    new,
+    old,
+    None,
+    input_ids,
+    mask,
+    beta,
+    advantages_1d,
 )
 assert len(result) == 7
 assert torch.isfinite(result[0]), f"1D advantages: loss not finite"
 print(f"PASS: 1D advantages, loss={result[0].item():.4f}")
 
 # Test 2D advantages (already correct shape)
-new2 = torch.randn(B, S, requires_grad=True)
+new2 = torch.randn(B, S, requires_grad = True)
 advantages_2d = torch.randn(B, 1)
 result2 = grpo_compute_loss(
-    ref, new2, old, None, input_ids, mask, beta, advantages_2d,
+    ref,
+    new2,
+    old,
+    None,
+    input_ids,
+    mask,
+    beta,
+    advantages_2d,
 )
 assert len(result2) == 7
 assert torch.isfinite(result2[0]), f"2D advantages: loss not finite"
@@ -32,11 +48,16 @@ print(f"PASS: 2D advantages, loss={result2[0].item():.4f}")
 
 # Test various batch/seq sizes
 for b, s in [(1, 1), (1, 32), (8, 4)]:
-    new_t = torch.randn(b, s, requires_grad=True)
+    new_t = torch.randn(b, s, requires_grad = True)
     r = grpo_compute_loss(
-        torch.randn(b, s), new_t, torch.randn(b, s), None,
-        torch.randint(0, 100, (b, s)), torch.ones(b, s),
-        beta, torch.randn(b),
+        torch.randn(b, s),
+        new_t,
+        torch.randn(b, s),
+        None,
+        torch.randint(0, 100, (b, s)),
+        torch.ones(b, s),
+        beta,
+        torch.randn(b),
     )
     assert torch.isfinite(r[0]), f"B={b},S={s}: loss not finite"
     print(f"PASS: B={b}, S={s}, loss={r[0].item():.4f}")

--- a/test_21_partial_mask.py
+++ b/test_21_partial_mask.py
@@ -1,0 +1,33 @@
+"""Test with partial completion mask (zeros in mask), not all-ones."""
+
+import sys, torch
+
+sys.path.insert(0, "unsloth_zoo_repo")
+from unsloth_zoo.rl_replacements import grpo_compute_loss
+
+B, S = 4, 16
+ref = torch.randn(B, S)
+new = torch.randn(B, S, requires_grad=True)
+old = torch.randn(B, S)
+input_ids = torch.randint(0, 100, (B, S))
+beta = 0.1
+advantages = torch.randn(B)
+
+# Mask with varying completion lengths per sample
+mask = torch.zeros(B, S)
+mask[0, :4] = 1.0
+mask[1, :8] = 1.0
+mask[2, :12] = 1.0
+mask[3, :16] = 1.0
+
+result = grpo_compute_loss(ref, new, old, None, input_ids, mask, beta, advantages)
+loss, comp_len, mean_kl, _, _, coef_1, out_mask = result
+
+assert torch.isfinite(loss), f"Loss not finite: {loss}"
+assert torch.isfinite(mean_kl), f"mean_kl not finite: {mean_kl}"
+# Completion length should be mean of [4, 8, 12, 16] = 10.0
+assert abs(comp_len.item() - 10.0) < 0.01, f"Expected comp_len=10.0, got {comp_len.item()}"
+
+loss.backward()
+assert new.grad is not None
+print(f"PASS: partial mask, loss={loss.item():.4f}, comp_len={comp_len.item():.1f}")

--- a/test_22_negative_advantages.py
+++ b/test_22_negative_advantages.py
@@ -1,0 +1,33 @@
+"""Test with all-negative and all-positive advantages (clipping edge cases)."""
+
+import sys, torch
+
+sys.path.insert(0, "unsloth_zoo_repo")
+from unsloth_zoo.rl_replacements import grpo_compute_loss
+
+B, S = 4, 8
+ref = torch.randn(B, S)
+old = torch.randn(B, S)
+input_ids = torch.randint(0, 100, (B, S))
+mask = torch.ones(B, S)
+beta = 0.1
+
+# All-negative advantages
+new1 = torch.randn(B, S, requires_grad=True)
+adv_neg = -torch.abs(torch.randn(B)) - 0.1  # guarantee negative
+r1 = grpo_compute_loss(ref, new1, old, None, input_ids, mask, beta, adv_neg)
+assert torch.isfinite(r1[0]), f"All-negative adv: loss not finite"
+
+# All-positive advantages
+new2 = torch.randn(B, S, requires_grad=True)
+adv_pos = torch.abs(torch.randn(B)) + 0.1  # guarantee positive
+r2 = grpo_compute_loss(ref, new2, old, None, input_ids, mask, beta, adv_pos)
+assert torch.isfinite(r2[0]), f"All-positive adv: loss not finite"
+
+# Zero advantages
+new3 = torch.randn(B, S, requires_grad=True)
+adv_zero = torch.zeros(B)
+r3 = grpo_compute_loss(ref, new3, old, None, input_ids, mask, beta, adv_zero)
+assert torch.isfinite(r3[0]), f"Zero adv: loss not finite"
+
+print(f"PASS: neg_adv loss={r1[0].item():.4f}, pos_adv loss={r2[0].item():.4f}, zero_adv loss={r3[0].item():.4f}")

--- a/test_23_extreme_logps.py
+++ b/test_23_extreme_logps.py
@@ -1,0 +1,36 @@
+"""Test numerical stability with extreme log-probability values."""
+
+import sys, torch
+
+sys.path.insert(0, "unsloth_zoo_repo")
+from unsloth_zoo.rl_replacements import grpo_compute_loss
+
+B, S = 2, 8
+input_ids = torch.randint(0, 100, (B, S))
+mask = torch.ones(B, S)
+beta = 0.1
+advantages = torch.randn(B)
+
+# Very small logps (large negative values)
+new1 = torch.randn(B, S, requires_grad=True) - 20.0
+ref1 = torch.randn(B, S) - 20.0
+old1 = torch.randn(B, S) - 20.0
+r1 = grpo_compute_loss(ref1, new1, old1, None, input_ids, mask, beta, advantages)
+assert torch.isfinite(r1[0]), f"Small logps: loss not finite: {r1[0]}"
+print(f"PASS: small logps, loss={r1[0].item():.4f}")
+
+# Logps near zero
+new2 = torch.randn(B, S, requires_grad=True) * 0.01
+ref2 = torch.randn(B, S) * 0.01
+old2 = torch.randn(B, S) * 0.01
+r2 = grpo_compute_loss(ref2, new2, old2, None, input_ids, mask, beta, advantages)
+assert torch.isfinite(r2[0]), f"Near-zero logps: loss not finite: {r2[0]}"
+print(f"PASS: near-zero logps, loss={r2[0].item():.4f}")
+
+# Identical ref and new (KL should be ~0)
+shared = torch.randn(B, S)
+new3 = shared.clone().requires_grad_(True)
+r3 = grpo_compute_loss(shared, new3, shared.clone(), None, input_ids, mask, beta, advantages)
+assert torch.isfinite(r3[0]), f"Identical logps: loss not finite"
+assert abs(r3[2].item()) < 0.01, f"Expected ~0 KL for identical ref/new, got {r3[2].item()}"
+print(f"PASS: identical ref/new, mean_kl={r3[2].item():.6f}")

--- a/test_24_single_token_sequence.py
+++ b/test_24_single_token_sequence.py
@@ -1,0 +1,30 @@
+"""Test edge case: single token sequence (S=1) and single sample (B=1)."""
+
+import sys, torch
+
+sys.path.insert(0, "unsloth_zoo_repo")
+from unsloth_zoo.rl_replacements import grpo_compute_loss
+
+# B=1, S=1: minimal possible input
+ref = torch.randn(1, 1)
+new = torch.randn(1, 1, requires_grad=True)
+old = torch.randn(1, 1)
+input_ids = torch.randint(0, 100, (1, 1))
+mask = torch.ones(1, 1)
+beta = 0.1
+advantages = torch.randn(1)
+
+result = grpo_compute_loss(ref, new, old, None, input_ids, mask, beta, advantages)
+assert len(result) == 7
+loss = result[0]
+assert torch.isfinite(loss), f"B=1,S=1: loss not finite: {loss}"
+loss.backward()
+assert new.grad is not None
+print(f"PASS: B=1,S=1, loss={loss.item():.4f}")
+
+# Test with sequence-level IS on single token
+new2 = torch.randn(1, 1, requires_grad=True)
+r2 = grpo_compute_loss(ref, new2, old, None, input_ids, mask, beta, advantages,
+                        importance_sampling_level="sequence")
+assert torch.isfinite(r2[0]), f"Sequence IS with S=1: loss not finite"
+print(f"PASS: sequence IS with S=1, loss={r2[0].item():.4f}")

--- a/test_25_epsilon_asymmetric.py
+++ b/test_25_epsilon_asymmetric.py
@@ -1,0 +1,33 @@
+"""Test asymmetric epsilon_low != epsilon_high clipping."""
+
+import sys, torch
+
+sys.path.insert(0, "unsloth_zoo_repo")
+from unsloth_zoo.rl_replacements import grpo_compute_loss
+
+B, S = 4, 8
+ref = torch.randn(B, S)
+old = torch.randn(B, S)
+input_ids = torch.randint(0, 100, (B, S))
+mask = torch.ones(B, S)
+beta = 0.1
+advantages = torch.randn(B)
+
+configs = [
+    ("tight_low", 0.05, 0.3),
+    ("tight_high", 0.3, 0.05),
+    ("symmetric", 0.2, 0.2),
+    ("zero_low", 0.0, 0.2),
+    ("zero_high", 0.2, 0.0),
+]
+
+for label, eps_low, eps_high in configs:
+    new = torch.randn(B, S, requires_grad=True)
+    r = grpo_compute_loss(
+        ref, new, old, None, input_ids, mask, beta, advantages,
+        loss_type="grpo", epsilon_low=eps_low, epsilon_high=eps_high,
+    )
+    assert torch.isfinite(r[0]), f"{label}: loss not finite"
+    print(f"PASS: {label} (eps_low={eps_low}, eps_high={eps_high}), loss={r[0].item():.4f}")
+
+print("PASS: All asymmetric epsilon configs OK")

--- a/test_26_delta_kwarg_clamp.py
+++ b/test_26_delta_kwarg_clamp.py
@@ -1,0 +1,35 @@
+"""Test delta kwarg which clamps coef_1 max in GRPO loss."""
+
+import sys, torch
+
+sys.path.insert(0, "unsloth_zoo_repo")
+from unsloth_zoo.rl_replacements import grpo_compute_loss
+
+B, S = 4, 8
+ref = torch.randn(B, S)
+# Make new very different from old to produce large coef_1
+old = torch.randn(B, S)
+input_ids = torch.randint(0, 100, (B, S))
+mask = torch.ones(B, S)
+beta = 0.1
+advantages = torch.randn(B)
+
+# With delta=None (no clamp on coef_1)
+new1 = torch.randn(B, S, requires_grad=True)
+r_none = grpo_compute_loss(ref, new1, old, None, input_ids, mask, beta, advantages,
+                            loss_type="grpo", delta=None)
+assert torch.isfinite(r_none[0])
+
+# With delta=1.5 (clamp coef_1 at 1.5)
+new2 = new1.detach().clone().requires_grad_(True)
+r_delta = grpo_compute_loss(ref, new2, old, None, input_ids, mask, beta, advantages,
+                             loss_type="grpo", delta=1.5)
+assert torch.isfinite(r_delta[0])
+
+# With delta=1.0 (tight clamp)
+new3 = new1.detach().clone().requires_grad_(True)
+r_tight = grpo_compute_loss(ref, new3, old, None, input_ids, mask, beta, advantages,
+                              loss_type="grpo", delta=1.0)
+assert torch.isfinite(r_tight[0])
+
+print(f"PASS: delta=None loss={r_none[0].item():.4f}, delta=1.5 loss={r_delta[0].item():.4f}, delta=1.0 loss={r_tight[0].item():.4f}")

--- a/test_27_bnpo_vs_grpo_normalization.py
+++ b/test_27_bnpo_vs_grpo_normalization.py
@@ -1,0 +1,44 @@
+"""Verify BNPO and GRPO produce different losses due to different normalization."""
+
+import sys, torch
+
+sys.path.insert(0, "unsloth_zoo_repo")
+from unsloth_zoo.rl_replacements import grpo_compute_loss
+
+torch.manual_seed(99)
+B, S = 4, 8
+ref = torch.randn(B, S)
+old = torch.randn(B, S)
+input_ids = torch.randint(0, 100, (B, S))
+mask = torch.ones(B, S)
+beta = 0.1
+advantages = torch.randn(B)
+new_base = torch.randn(B, S)
+
+# GRPO: mean over samples of (per-sample mean)
+new1 = new_base.clone().requires_grad_(True)
+r_grpo = grpo_compute_loss(ref, new1, old, None, input_ids, mask, beta, advantages, loss_type="grpo")
+
+# BNPO: sum / total_mask_count (global mean, not per-sample then mean)
+new2 = new_base.clone().requires_grad_(True)
+r_bnpo = grpo_compute_loss(ref, new2, old, None, input_ids, mask, beta, advantages, loss_type="bnpo")
+
+assert torch.isfinite(r_grpo[0]) and torch.isfinite(r_bnpo[0])
+
+# With uniform mask they should actually be the same, test with non-uniform
+mask2 = torch.zeros(B, S)
+mask2[0, :2] = 1.0
+mask2[1, :4] = 1.0
+mask2[2, :6] = 1.0
+mask2[3, :8] = 1.0
+
+new3 = new_base.clone().requires_grad_(True)
+r_grpo2 = grpo_compute_loss(ref, new3, old, None, input_ids, mask2, beta, advantages, loss_type="grpo")
+
+new4 = new_base.clone().requires_grad_(True)
+r_bnpo2 = grpo_compute_loss(ref, new4, old, None, input_ids, mask2, beta, advantages, loss_type="bnpo")
+
+assert torch.isfinite(r_grpo2[0]) and torch.isfinite(r_bnpo2[0])
+# With non-uniform mask, GRPO and BNPO should differ
+assert r_grpo2[0].item() != r_bnpo2[0].item(), "GRPO and BNPO should differ with non-uniform mask"
+print(f"PASS: grpo={r_grpo2[0].item():.4f}, bnpo={r_bnpo2[0].item():.4f} (differ with non-uniform mask)")

--- a/test_28_signature_introspection.py
+++ b/test_28_signature_introspection.py
@@ -1,0 +1,23 @@
+"""Verify grpo_compute_loss function signature has sampling_per_token_logps as 4th param."""
+
+import sys, inspect
+
+sys.path.insert(0, "unsloth_zoo_repo")
+from unsloth_zoo.rl_replacements import grpo_compute_loss
+
+sig = inspect.signature(grpo_compute_loss)
+params = list(sig.parameters.keys())
+
+expected_order = ["ref", "new", "old", "sampling_per_token_logps", "input_ids", "mask", "beta", "advantages"]
+
+for i, (expected, actual) in enumerate(zip(expected_order, params)):
+    assert expected == actual, f"Param {i}: expected '{expected}', got '{actual}'"
+
+assert params[-1] == "kwargs", f"Last param should be **kwargs, got '{params[-1]}'"
+
+# Verify sampling_per_token_logps is POSITIONAL_OR_KEYWORD (not keyword-only)
+sp = sig.parameters["sampling_per_token_logps"]
+assert sp.kind == inspect.Parameter.POSITIONAL_OR_KEYWORD, \
+    f"sampling_per_token_logps should be POSITIONAL_OR_KEYWORD, got {sp.kind}"
+
+print(f"PASS: Function signature correct: {', '.join(params[:8])}, **kwargs")

--- a/test_29_sequence_is_with_partial_mask.py
+++ b/test_29_sequence_is_with_partial_mask.py
@@ -1,0 +1,42 @@
+"""Test sequence-level importance sampling with partial mask (division by mask sum)."""
+
+import sys, torch
+
+sys.path.insert(0, "unsloth_zoo_repo")
+from unsloth_zoo.rl_replacements import grpo_compute_loss
+
+B, S = 4, 12
+ref = torch.randn(B, S)
+old = torch.randn(B, S)
+input_ids = torch.randint(0, 100, (B, S))
+beta = 0.1
+advantages = torch.randn(B)
+
+# Partial mask with different completion lengths
+mask = torch.zeros(B, S)
+mask[0, :3] = 1.0
+mask[1, :6] = 1.0
+mask[2, :9] = 1.0
+mask[3, :12] = 1.0
+
+new = torch.randn(B, S, requires_grad=True)
+result = grpo_compute_loss(
+    ref, new, old, None, input_ids, mask, beta, advantages,
+    importance_sampling_level="sequence",
+)
+assert len(result) == 7
+loss, comp_len, mean_kl = result[0], result[1], result[2]
+assert torch.isfinite(loss), f"Sequence IS partial mask: loss not finite"
+assert torch.isfinite(mean_kl), f"mean_kl not finite"
+
+loss.backward()
+assert new.grad is not None
+# Gradient should be zero where mask is zero
+for i in range(B):
+    mask_end = [3, 6, 9, 12][i]
+    if mask_end < S:
+        # With sequence-level IS, gradients can still flow to unmasked positions
+        # through the sequence-level aggregation, but the final loss mask zeros them
+        pass
+
+print(f"PASS: sequence IS + partial mask, loss={loss.item():.4f}, comp_len={comp_len.item():.1f}")

--- a/test_30_callsite_arg_count.py
+++ b/test_30_callsite_arg_count.py
@@ -1,0 +1,39 @@
+"""Verify the PR call site passes exactly 8 positional args matching the function signature.
+Parse the actual source file to check arg count at the call site."""
+
+import sys, ast
+
+sys.path.insert(0, "unsloth_zoo_repo")
+
+# Read the PR-fixed source
+with open("unsloth/models/rl_replacements.py", "r") as f:
+    source = f.read()
+
+tree = ast.parse(source)
+
+# Find all calls to grpo_compute_loss_slow
+calls_found = []
+for node in ast.walk(tree):
+    if isinstance(node, ast.Call):
+        func = node.func
+        if isinstance(func, ast.Name) and func.id == "grpo_compute_loss_slow":
+            calls_found.append(node)
+
+assert len(calls_found) >= 1, "Expected at least 1 call to grpo_compute_loss_slow"
+
+for i, call in enumerate(calls_found):
+    n_positional = len(call.args)
+    kwarg_names = [kw.arg for kw in call.keywords]
+
+    # Must have exactly 8 positional args
+    assert n_positional == 8, \
+        f"Call {i}: expected 8 positional args, got {n_positional}"
+
+    # sampling_per_token_logps must NOT be in kwargs (it's positional now)
+    assert "sampling_per_token_logps" not in kwarg_names, \
+        f"Call {i}: sampling_per_token_logps should not be a kwarg"
+
+    print(f"PASS: Call {i} at line {call.lineno}: {n_positional} positional args, "
+          f"{len(kwarg_names)} kwargs, no duplicate sampling_per_token_logps")
+
+print(f"PASS: All {len(calls_found)} grpo_compute_loss_slow calls have correct arg structure")

--- a/unsloth/models/rl_replacements.py
+++ b/unsloth/models/rl_replacements.py
@@ -1131,6 +1131,7 @@ def grpo_trainer_compute_loss(function_name, function):
                 ref_logps,
                 per_token_logps,
                 old_logps,
+                sampling_per_token_logps,
                 input_ids,
                 completion_mask,
                 self.beta,
@@ -1151,7 +1152,6 @@ def grpo_trainer_compute_loss(function_name, function):
                 num_items_in_batch = num_items_in_batch,
                 current_gradient_accumulation_steps = current_gradient_accumulation_steps,
                 num_processes = num_processes,
-                sampling_per_token_logps = sampling_per_token_logps,
             )
         else:
             if hasattr(self.args, "loss_type"):


### PR DESCRIPTION
## Staging mirror of unslothai/unsloth#4927

Original PR: https://github.com/unslothai/unsloth/pull/4927
Author: Shivamjohri247

This is a staging copy for review and editing. Once finalized, changes will be pushed back to the original PR.

---

### Original description

## Summary

Fixes #4885

The call to `grpo_compute_loss_slow` in the `compute_loss` replacement for `GRPOTrainer` was passing arguments in the wrong positions, causing a crash during GRPO training.

### Root Cause

`grpo_compute_loss` (and its `torch.compile`d variant `grpo_compute_loss_slow`) has this signature (defined in `unsloth-zoo`):

```python
def grpo_compute_loss(ref, new, old, sampling_per_token_logps, input_ids, mask, beta, advantages, **kwargs):
```

The call site in `unsloth/models/rl_replacements.py:1130` was **skipping** the 4th positional argument (`sampling_per_token_logps`) and also passing it as a keyword arg at the end:

```python
# BEFORE (broken)
grpo_compute_loss_slow(
    ref_logps,           # ref           ✓
    per_token_logps,     # new           ✓
    old_logps,           # old           ✓
    input_ids,           # → sampling_per_token_logps  ✗ WRONG
    completion_mask,     # → input_ids               ✗ WRONG
    self.beta,           # → mask                    ✗ WRONG
    advantages,          # → beta                    ✗ WRONG
    ...,
    sampling_per_token_logps = sampling_per_token_logps,  # duplicate! causes TypeError
)
```

This caused a `TypeError: got multiple values for argument 'sampling_per_token_logps'` at runtime, since the 4th positional slot was already filled by `input_ids`, and then the same parameter name was also provided as a keyword argument.

### Fix

Insert `sampling_per_token_logps` as the 4th positional argument (matching the function signature) and remove it from keyword args:

```python
# AFTER (fixed)
grpo_compute_loss_slow(
    ref_logps,                  # ref                       ✓
    per_token_logps,            # new                       ✓
    old_logps,                  # old                       ✓
    sampling_per_token_logps,   # sampling_per_token_logps  ✓ NEW
    input_ids,                  # input_ids                 ✓
    completion_mask,            # mask                      ✓
    self.beta,                  # beta                      ✓
    advantages,                 # advantages                ✓
    ...,
    # sampling_per_token_logps removed from kwargs
)
```

This now matches the calling convention used by `UnslothEfficientGRPO.forward()` (the fast/compiled path) which already passes args in the correct order.

### Impact

- **Before**: GRPO training crashes with `TypeError` when using the slow loss computation path (when `per_token_logps is not None`)
- **After**: Arguments correctly map to their intended parameters

## Test plan

- [ ] Run GRPO training with `GRPOTrainer` using a model that triggers the `grpo_compute_loss_slow` path (i.e. where `_get_per_token_logps` returns non-None logprobs)
- [ ] Verify training completes without `TypeError`
- [ ] Verify loss values and metrics are computed correctly (no NaN, reasonable magnitudes)

---

**This PR contains test changes only (10 files). Code changes are in a separate PR.**

Test files:
- `test_01_pre_pr_typeerror.py`
- `test_02_post_pr_basic.py`
- `test_03_sampling_none.py`
- `test_04_old_logps_none.py`
- `test_05_beta_zero.py`
- `test_06_loss_types.py`
- `test_07_importance_sampling_levels.py`
- `test_08_return_shape.py`
- `test_09_vllm_importance_sampling.py`
- `test_10_1d_advantages.py`