### PR TITLE
[staging CI] validate pester-guard-ci.yml

### DIFF
--- a/.github/workflows/pester-guard-ci.yml
+++ b/.github/workflows/pester-guard-ci.yml
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+# Copyright 2026-present the Unsloth AI Inc. team. All rights reserved.
+
+# The Pester bootstrap guard runs on windows-latest inside the `pester` job of
+# studio-windows-inference-smoke.yml, which covers edits to that workflow.
+# It does not cover edits to the guard itself: that workflow has no job-level
+# path gating, so listing a .py file there would launch all eight Windows smoke
+# jobs, four of which download GGUF models and run for 30+ minutes.
+#
+# This runs the same guard on the same OS in about a minute, so a Windows-only
+# break in the guard is caught by the PR that introduces it.
+
+name: Pester guard
+
+on:
+  pull_request:
+    paths:
+      - 'tests/studio/test_pester_bootstrap_hardening.py'
+      - '.github/workflows/pester-guard-ci.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  guard:
+    name: Pester bootstrap guard
+    runs-on: windows-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: '3.12'
+
+      - name: Guard the Pester bootstrap
+        shell: bash
+        run: |
+          python -m pip install --quiet pyyaml pytest
+          python -m pytest tests/studio/test_pester_bootstrap_hardening.py -q

--- a/.github/workflows/studio-windows-inference-smoke.yml
+++ b/.github/workflows/studio-windows-inference-smoke.yml
@@ -32,6 +32,10 @@ on:
       # runs them. Scoped to *.ps1 so python-only changes under tests/studio do
       # not pull in the GGUF smoke jobs.
       - 'tests/studio/*.ps1'
+      # The guard runs on windows-latest, so editing it must run this job. Without
+      # this, a Windows-only break in the guard lands and only shows up later, on an
+      # unrelated PR.
+      - 'tests/studio/test_pester_bootstrap_hardening.py'
       - '.github/workflows/studio-windows-inference-smoke.yml'
   push:
     branches: [main, pip]

--- a/.github/workflows/studio-windows-inference-smoke.yml
+++ b/.github/workflows/studio-windows-inference-smoke.yml
@@ -32,10 +32,6 @@ on:
       # runs them. Scoped to *.ps1 so python-only changes under tests/studio do
       # not pull in the GGUF smoke jobs.
       - 'tests/studio/*.ps1'
-      # The guard runs on windows-latest, so editing it must run this job. Without
-      # this, a Windows-only break in the guard lands and only shows up later, on an
-      # unrelated PR.
-      - 'tests/studio/test_pester_bootstrap_hardening.py'
       - '.github/workflows/studio-windows-inference-smoke.yml'
   push:
     branches: [main, pip]

--- a/tests/studio/test_pester_bootstrap_hardening.py
+++ b/tests/studio/test_pester_bootstrap_hardening.py
@@ -112,7 +112,13 @@ def test_the_guard_runs_from_the_workflow_it_guards():
     on = workflow.get("on") or workflow.get(True)
     # as_posix(), not str(): this runs on windows-latest, where str() would give
     # backslashes and never match the forward-slash paths in the YAML.
-    assert _WORKFLOW.relative_to(REPO_ROOT).as_posix() in on["pull_request"]["paths"]
+    paths = on["pull_request"]["paths"]
+    assert _WORKFLOW.relative_to(REPO_ROOT).as_posix() in paths
+    # `tests/studio/*.ps1` does not cover this file, so editing the guard alone used
+    # to skip the job that runs it, which is how a Windows-only break got merged.
+    assert (
+        Path(__file__).resolve().relative_to(REPO_ROOT).as_posix() in paths
+    ), "editing this guard must run the Windows job it guards"
     steps = workflow["jobs"]["pester"]["steps"]
     assert any(
         Path(__file__).name in (s.get("run") or "") for s in steps

--- a/tests/studio/test_pester_bootstrap_hardening.py
+++ b/tests/studio/test_pester_bootstrap_hardening.py
@@ -29,6 +29,7 @@ import yaml
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 _WORKFLOW = REPO_ROOT / ".github" / "workflows" / "studio-windows-inference-smoke.yml"
+_GUARD_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "pester-guard-ci.yml"
 
 
 def _bootstrap_step() -> dict:
@@ -112,17 +113,22 @@ def test_the_guard_runs_from_the_workflow_it_guards():
     on = workflow.get("on") or workflow.get(True)
     # as_posix(), not str(): this runs on windows-latest, where str() would give
     # backslashes and never match the forward-slash paths in the YAML.
-    paths = on["pull_request"]["paths"]
-    assert _WORKFLOW.relative_to(REPO_ROOT).as_posix() in paths
-    # `tests/studio/*.ps1` does not cover this file, so editing the guard alone used
-    # to skip the job that runs it, which is how a Windows-only break got merged.
-    assert (
-        Path(__file__).resolve().relative_to(REPO_ROOT).as_posix() in paths
-    ), "editing this guard must run the Windows job it guards"
+    assert _WORKFLOW.relative_to(REPO_ROOT).as_posix() in on["pull_request"]["paths"]
     steps = workflow["jobs"]["pester"]["steps"]
     assert any(
         Path(__file__).name in (s.get("run") or "") for s in steps
     ), "the pester job must run this guard, or a workflow-only edit skips it entirely"
+
+
+def test_editing_the_guard_runs_it_on_windows():
+    """The heavy workflow has no job-level gating, so the guard gets its own cheap one."""
+    workflow = yaml.safe_load(_GUARD_WORKFLOW.read_text(encoding = "utf-8"))
+    on = workflow.get("on") or workflow.get(True)
+    assert Path(__file__).resolve().relative_to(REPO_ROOT).as_posix() in on["pull_request"]["paths"]
+    jobs = list(workflow["jobs"].values())
+    assert len(jobs) == 1, "keep this workflow to one job, it exists to be cheap"
+    assert jobs[0]["runs-on"] == "windows-latest", "the bug this catches is Windows-only"
+    assert any(Path(__file__).name in (s.get("run") or "") for s in jobs[0]["steps"])
 
 
 def test_network_is_skipped_when_the_image_already_satisfies_the_minimum():


### PR DESCRIPTION
Validation only. Checks that the new one-job Pester guard workflow runs on windows-latest and that the heavy smoke suite is not triggered by a guard-only change.