### PR TITLE
probe: font scale diagnostics (staging only, never merge)

### DIFF
--- a/tests/studio/playwright_ui_font_scale.py
+++ b/tests/studio/playwright_ui_font_scale.py
@@ -75,6 +75,8 @@ MEASURE_JS = """
   return {
     root: parseFloat(getComputedStyle(document.documentElement).fontSize),
     uiAttr: document.documentElement.getAttribute("data-ui-font-size"),
+    scaleVar: getComputedStyle(document.documentElement).getPropertyValue("--ui-font-scale").trim(),
+    navClass: nav ? nav.className : null,
     navFont: fs(nav),
     navLine: lh(nav),
     sidebarW: sidebar ? sidebar.getBoundingClientRect().width : null,
@@ -84,7 +86,9 @@ MEASURE_JS = """
 
 
 def measure(page):
-    return page.evaluate(MEASURE_JS)
+    m = page.evaluate(MEASURE_JS)
+    print(f"[font-scale] MEASURE {m}", flush = True)
+    return m
 
 
 def set_input(page, label, value):
@@ -232,9 +236,15 @@ def main():
         tab = page.get_by_role("radio").filter(has_text = "Discover").first
         tab.wait_for(state = "visible", timeout = 15000)
         tab_font = tab.evaluate("el => parseFloat(getComputedStyle(el).fontSize)")
+        print("[font-scale] TAB " + tab.evaluate(
+            "el => JSON.stringify({cls: el.className, fs: getComputedStyle(el).fontSize,"
+            " scale: getComputedStyle(document.documentElement).getPropertyValue('--ui-font-scale'),"
+            " attr: document.documentElement.getAttribute('data-ui-font-size'),"
+            " root: getComputedStyle(document.documentElement).fontSize})"
+        ), flush = True)
         # text-ui-12p5 at scale 0.75; 16px means twMerge dropped the token.
         if not near(tab_font, 12.5 * 12 / 16):
-            fail(f"hub tab font did not scale (twMerge drop?): {tab_font}")
+            print(f"[font-scale] WOULD-FAIL hub tab font: {tab_font}", flush = True)
         icon_w = page.evaluate(
             "() => { const el = document.querySelector('.size-icon');"
             " return el ? parseFloat(getComputedStyle(el).width) : null; }"
@@ -256,7 +266,7 @@ def main():
             if not near(final[key], base[key], 0.35):
                 fail(f"default drifted for {key}: {base[key]} -> {final[key]}")
         if final["uiAttr"] is not None:
-            fail(f"data-ui-font-size present at default: {final['uiAttr']}")
+            print(f"[font-scale] WOULD-FAIL attr at default: {final['uiAttr']}", flush = True)
 
         page.screenshot(path = str(ART / "restored-default.png"))
         browser.close()


### PR DESCRIPTION
Diagnostic run on a staging repo to keep the org queue free. Prints the measured root size, --ui-font-scale, data-ui-font-size and the hub tab class/size instead of stopping at the first assertion. Not for merge.